### PR TITLE
Fix units in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ returns string representing encoded polyline
 returns array of point representing decoded polyline
 
 - `string` is an encoded polyline representation
-- `factor` - optional (defaults to `10e5`), factor by which coordinates are divided after decoding; use factor `10e6` when decoding polylines from OSM data ([OSRM], [mapzen] etc.)
+- `factor` - optional (defaults to `1e5`), factor by which coordinates are divided after decoding; use factor `1e6` when decoding polylines from OSM data ([OSRM], [mapzen] etc.)
 
 [OSRM]: http://project-osrm.org/
 [mapzen]: https://mapzen.com/


### PR DESCRIPTION
Noticed an error in the README documentation for this module when I tried using the values listed and got broken lon/lat tuples back. Wanted to open a PR upstream if you'd like to merge it to update the documentation on NPM.